### PR TITLE
Use PHP DOM 

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -25,9 +25,12 @@
       <path value="$PROJECT_DIR$/vendor/symfony/filesystem" />
       <path value="$PROJECT_DIR$/vendor/symfony/webpack-encore-bundle" />
       <path value="$PROJECT_DIR$/vendor/symfony/deprecation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/twig-bundle" />
+      <path value="$PROJECT_DIR$/vendor/symfony/translation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/twig-bridge" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.4">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": "^7.4||^8.1",
-    "ext-simplexml": "*",
+    "ext-dom": "*",
     "twig/twig": "^3.3",
     "symfony/http-kernel": "^4.4|^5.4|^6.1",
     "symfony/webpack-encore-bundle": "^v1.15",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": "^7.4||^8.1",
     "ext-simplexml": "*",
     "twig/twig": "^3.3",
     "symfony/http-kernel": "^5.4|^6.1",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,11 @@
     "php": ">=8.1",
     "ext-simplexml": "*",
     "twig/twig": "^3.3",
-    "symfony/http-kernel": "^5.4 | ^6.1",
-    "symfony/webpack-encore-bundle": "^1.14",
-    "symfony/dependency-injection": "^5.4 | ^6.1"
+    "symfony/http-kernel": "^5.4|^6.1",
+    "symfony/webpack-encore-bundle": "^v1.15",
+    "symfony/dependency-injection": "^5.4|^6.1",
+    "symfony/twig-bridge": "^5.4|^6.1",
+    "symfony/twig-bundle": "^5.4|^6.1"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "php": ">=8.1",
     "ext-simplexml": "*",
     "twig/twig": "^3.3",
-    "symfony/http-kernel": "^5.4",
+    "symfony/http-kernel": "^5.4 | ^6.1",
     "symfony/webpack-encore-bundle": "^1.14",
-    "symfony/dependency-injection": "^5.4"
+    "symfony/dependency-injection": "^5.4 | ^6.1"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "php": "^7.4||^8.1",
     "ext-simplexml": "*",
     "twig/twig": "^3.3",
-    "symfony/http-kernel": "^5.4|^6.1",
+    "symfony/http-kernel": "^4.4|^5.4|^6.1",
     "symfony/webpack-encore-bundle": "^v1.15",
-    "symfony/dependency-injection": "^5.4|^6.1",
-    "symfony/twig-bridge": "^5.4|^6.1",
-    "symfony/twig-bundle": "^5.4|^6.1"
+    "symfony/dependency-injection": "^4.4|^5.4|^6.1",
+    "symfony/twig-bridge": "^4.4|^5.4|^6.1",
+    "symfony/twig-bundle": "^4.4|^5.4|^6.1"
   },
   "archive": {
     "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67f14c126e15c3295accff92c09226ea",
+    "content-hash": "db3dc0edf5e0c5cd14c3a0695214922b",
     "packages": [
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2120a40366f9d5a1ccaa10906694460c",
+    "content-hash": "67f14c126e15c3295accff92c09226ea",
     "packages": [
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -50,9 +55,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -106,16 +111,16 @@
         },
         {
             "name": "psr/log",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
@@ -124,7 +129,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -150,9 +155,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/2.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-07-14T16:41:46+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "symfony/asset",
@@ -305,41 +310,39 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.9",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "beecae161577305926ec078c4ed973f2b98880b3"
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/beecae161577305926ec078c4ed973f2b98880b3",
-                "reference": "beecae161577305926ec078c4ed973f2b98880b3",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5635ff016a814d7984b1c4644ad28e7df546077b",
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1.1",
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/polyfill-php81": "^1.22",
-                "symfony/service-contracts": "^1.1.6|^2"
+                "symfony/service-contracts": "^1.1.6|^2.0|^3.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
-                "symfony/config": "<5.3",
-                "symfony/finder": "<4.4",
-                "symfony/proxy-manager-bridge": "<4.4",
-                "symfony/yaml": "<4.4.26"
+                "symfony/config": "<6.1",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<5.4",
+                "symfony/yaml": "<5.4"
             },
             "provide": {
-                "psr/container-implementation": "1.0",
-                "symfony/service-implementation": "1.0|2.0"
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^5.3|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/yaml": "^4.4.26|^5.0|^6.0"
+                "symfony/config": "^6.1",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -374,7 +377,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.9"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -390,11 +393,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-27T06:40:03+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -441,7 +444,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -615,7 +618,7 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
@@ -674,7 +677,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -757,16 +760,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "18f8a2a3ab703428143c27c055fd743ab7e7dcb1"
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/18f8a2a3ab703428143c27c055fd743ab7e7dcb1",
-                "reference": "18f8a2a3ab703428143c27c055fd743ab7e7dcb1",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/86119d294e51afe4d8e07da96b63332bd1f3f52c",
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c",
                 "shasum": ""
             },
             "require": {
@@ -809,7 +812,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.1.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -825,68 +828,66 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-21T13:34:40+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.9",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "34b121ad3dc761f35fe1346d2f15618f8cbf77f8"
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/34b121ad3dc761f35fe1346d2f15618f8cbf77f8",
-                "reference": "34b121ad3dc761f35fe1346d2f15618f8cbf77f8",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8aaede489900dda61aee208557f63bfa1bca0877",
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/log": "^1|^2",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^5.0|^6.0",
-                "symfony/http-foundation": "^5.3.7|^6.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/error-handler": "^6.1",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/browser-kit": "<5.4",
-                "symfony/cache": "<5.0",
-                "symfony/config": "<5.0",
-                "symfony/console": "<4.4",
-                "symfony/dependency-injection": "<5.3",
-                "symfony/doctrine-bridge": "<5.0",
-                "symfony/form": "<5.0",
-                "symfony/http-client": "<5.0",
-                "symfony/mailer": "<5.0",
-                "symfony/messenger": "<5.0",
-                "symfony/translation": "<5.0",
-                "symfony/twig-bridge": "<5.0",
-                "symfony/validator": "<5.0",
+                "symfony/cache": "<5.4",
+                "symfony/config": "<6.1",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<6.1",
+                "symfony/doctrine-bridge": "<5.4",
+                "symfony/form": "<5.4",
+                "symfony/http-client": "<5.4",
+                "symfony/mailer": "<5.4",
+                "symfony/messenger": "<5.4",
+                "symfony/translation": "<5.4",
+                "symfony/twig-bridge": "<5.4",
+                "symfony/validator": "<5.4",
                 "twig/twig": "<2.13"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
                 "symfony/browser-kit": "^5.4|^6.0",
-                "symfony/config": "^5.0|^6.0",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/css-selector": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/config": "^6.1",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dependency-injection": "^6.1",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
                 "symfony/http-client-contracts": "^1.1|^2|^3",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/routing": "^4.4|^5.0|^6.0",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0",
-                "symfony/translation": "^4.4|^5.0|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
                 "symfony/translation-contracts": "^1.1|^2|^3",
+                "symfony/uid": "^5.4|^6.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
@@ -921,7 +922,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.9"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -937,7 +938,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-27T07:09:08+00:00"
+            "time": "2022-06-26T17:06:14+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1105,85 +1106,6 @@
             "time": "2022-05-24T11:49:31+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-24T11:49:31+00:00"
-        },
-        {
             "name": "symfony/polyfill-php80",
             "version": "v1.26.0",
             "source": {
@@ -1267,102 +1189,22 @@
             "time": "2022-05-10T07:21:04+00:00"
         },
         {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
-                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-24T11:49:31+00:00"
-        },
-        {
             "name": "symfony/service-contracts",
-            "version": "v2.5.1",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1|^3"
+                "php": ">=8.1",
+                "psr/container": "^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -1373,7 +1215,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1383,7 +1225,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1410,7 +1255,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -1426,7 +1271,296 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-13T20:07:29+00:00"
+            "time": "2022-05-30T19:18:58+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/606be0f48e05116baef052f7f3abdb345c8e02cc",
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-27T17:24:16+00:00"
+        },
+        {
+            "name": "symfony/twig-bridge",
+            "version": "v6.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "320b9ec7db38b78ce2ea8173b925be55e697f8e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/320b9ec7db38b78ce2ea8173b925be55e697f8e5",
+                "reference": "320b9ec7db38b78ce2ea8173b925be55e697f8e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/translation-contracts": "^1.1|^2|^3",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/console": "<5.4",
+                "symfony/form": "<6.1",
+                "symfony/http-foundation": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/translation": "<5.4",
+                "symfony/workflow": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12",
+                "egulias/email-validator": "^2.1.10|^3",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/form": "^6.1",
+                "symfony/html-sanitizer": "^6.1",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/security-acl": "^2.8|^3.0",
+                "symfony/security-core": "^5.4|^6.0",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/security-http": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/web-link": "^5.4|^6.0",
+                "symfony/workflow": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
+                "twig/cssinliner-extra": "^2.12|^3",
+                "twig/inky-extra": "^2.12|^3",
+                "twig/markdown-extra": "^2.12|^3"
+            },
+            "suggest": {
+                "symfony/asset": "For using the AssetExtension",
+                "symfony/expression-language": "For using the ExpressionExtension",
+                "symfony/finder": "",
+                "symfony/form": "For using the FormExtension",
+                "symfony/html-sanitizer": "For using the HtmlSanitizerExtension",
+                "symfony/http-kernel": "For using the HttpKernelExtension",
+                "symfony/routing": "For using the RoutingExtension",
+                "symfony/security-core": "For using the SecurityExtension",
+                "symfony/security-csrf": "For using the CsrfExtension",
+                "symfony/security-http": "For using the LogoutUrlExtension",
+                "symfony/stopwatch": "For using the StopwatchExtension",
+                "symfony/translation": "For using the TranslationExtension",
+                "symfony/var-dumper": "For using the DumpExtension",
+                "symfony/web-link": "For using the WebLinkExtension",
+                "symfony/yaml": "For using the YamlExtension"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Twig\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Twig with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bridge/tree/v6.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-19T13:21:48+00:00"
+        },
+        {
+            "name": "symfony/twig-bundle",
+            "version": "v6.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bundle.git",
+                "reference": "a2abab10068525a7f5a879e40e411d369d688545"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/a2abab10068525a7f5a879e40e411d369d688545",
+                "reference": "a2abab10068525a7f5a879e40e411d369d688545",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "php": ">=8.1",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/twig-bridge": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<5.4",
+                "symfony/translation": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/framework-bundle": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/web-link": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\TwigBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bundle/tree/v6.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-27T16:55:36+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -1518,16 +1652,16 @@
         },
         {
             "name": "symfony/webpack-encore-bundle",
-            "version": "v1.14.1",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/webpack-encore-bundle.git",
-                "reference": "6b18be99bf2a5a402b80a2c00043fe0b365fe836"
+                "reference": "1fc386364200ca43108ff1871d86435b840ea67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/webpack-encore-bundle/zipball/6b18be99bf2a5a402b80a2c00043fe0b365fe836",
-                "reference": "6b18be99bf2a5a402b80a2c00043fe0b365fe836",
+                "url": "https://api.github.com/repos/symfony/webpack-encore-bundle/zipball/1fc386364200ca43108ff1871d86435b840ea67c",
+                "reference": "1fc386364200ca43108ff1871d86435b840ea67c",
                 "shasum": ""
             },
             "require": {
@@ -1535,7 +1669,9 @@
                 "symfony/asset": "^4.4 || ^5.0 || ^6.0",
                 "symfony/config": "^4.4 || ^5.0 || ^6.0",
                 "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
                 "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25.0",
                 "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
@@ -1569,7 +1705,7 @@
             "description": "Integration with your Symfony app & Webpack Encore!",
             "support": {
                 "issues": "https://github.com/symfony/webpack-encore-bundle/issues",
-                "source": "https://github.com/symfony/webpack-encore-bundle/tree/v1.14.1"
+                "source": "https://github.com/symfony/webpack-encore-bundle/tree/v1.15.0"
             },
             "funding": [
                 {
@@ -1585,7 +1721,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-03T17:55:32+00:00"
+            "time": "2022-07-06T13:36:43+00:00"
         },
         {
             "name": "twig/twig",
@@ -1671,6 +1807,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "php": "^7.4||^8.1",
         "ext-simplexml": "*"
     },
     "platform-dev": [],

--- a/src/Controller/StorybookController.php
+++ b/src/Controller/StorybookController.php
@@ -9,13 +9,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class StorybookController extends AbstractController
 {
-    #[
-        Route(
-            path: '/',
-            name: 'tct_render_storybook',
-            methods: ['POST']
-        )
-    ]
+    /**
+     * @Route (
+     *     path="/",
+     *     name="tct_render_storybook",
+     *     methods={"POST"}
+     * )
+     */
+    #[Route(path: '/', name: 'tct_render_storybook', methods: ['POST'])]
     public function storybookComponent(Request $request): Response
     {
         $template = $request->request->get('template');

--- a/src/Controller/StorybookController.php
+++ b/src/Controller/StorybookController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TwigComponentTools\TCTBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class StorybookController extends AbstractController
+{
+    #[
+        Route(
+            path: '/',
+            name: 'tct_render_storybook',
+            methods: ['POST']
+        )
+    ]
+    public function storybookComponent(Request $request): Response
+    {
+        $template = $request->request->get('template');
+        $data     = $request->request->all('data');
+
+        return $this->render($template, $data);
+    }
+}

--- a/src/DependencyInjection/TCTBundleExtension.php
+++ b/src/DependencyInjection/TCTBundleExtension.php
@@ -14,7 +14,7 @@ class TCTBundleExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
     }
 }

--- a/src/EventListener/ComponentTagInjectorListener.php
+++ b/src/EventListener/ComponentTagInjectorListener.php
@@ -5,6 +5,7 @@ namespace TwigComponentTools\TCTBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\VarDumper\VarDumper;
 use TwigComponentTools\TCTBundle\Loader\ComponentLoaderInterface;
 use TwigComponentTools\TCTBundle\TagRenderer\ComponentTagRenderInterface;
 
@@ -34,7 +35,6 @@ class ComponentTagInjectorListener implements EventSubscriberInterface
         $response         = $event->getResponse();
         $content          = $response->getContent();
         $loadedComponents = $this->componentLoader->getLoadedComponents();
-
         if (empty($loadedComponents)) {
             return;
         }
@@ -44,7 +44,6 @@ class ComponentTagInjectorListener implements EventSubscriberInterface
 
         $bodyTags = $this->componentTagRenderer->renderBodyTags($loadedComponents);
         $content  = $this->injectAtTag($content, 'TCT-BodyEntries', $bodyTags);
-
         $response->setContent($content);
     }
 

--- a/src/EventListener/ComponentTagInjectorListener.php
+++ b/src/EventListener/ComponentTagInjectorListener.php
@@ -5,7 +5,6 @@ namespace TwigComponentTools\TCTBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\VarDumper\VarDumper;
 use TwigComponentTools\TCTBundle\Loader\ComponentLoaderInterface;
 use TwigComponentTools\TCTBundle\TagRenderer\ComponentTagRenderInterface;
 

--- a/src/Naming/AtomicDesignComponentNaming.php
+++ b/src/Naming/AtomicDesignComponentNaming.php
@@ -9,21 +9,30 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
         'a' => 'Atom',
         'm' => 'Molecule',
         'o' => 'Organism',
+        'p' => 'Page',
         't' => 'Template',
     ];
 
     private string $typeOptions;
+    private array $typeAliases;
 
     public function __construct()
     {
-        $this->typeOptions = array_reduce(self::TYPES, fn ($carry, $type) => $carry.$type[0]);
+        $this->typeOptions = array_reduce(self::TYPES, fn($carry, $type) => $carry.$type[0]);
+        $this->typeAliases = array_map(fn($type) => '@' . strtolower($type), self::TYPES);
+        $this->typeAliases[] = '@components';
     }
 
+    /**
+     * Return the component name if it fits one of the component aliases (e.g. @components or @page)
+     */
     public function componentNameFromPath(string $path): ?string
     {
         $parts = explode('/', $path);
 
-        if ('@components' !== $parts[0]) {
+        $intersection = array_intersect($this->typeAliases, $parts);
+
+        if (empty($intersection)) {
             return null;
         }
 

--- a/src/Naming/AtomicDesignComponentNaming.php
+++ b/src/Naming/AtomicDesignComponentNaming.php
@@ -59,12 +59,11 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
      * OPageHeader
      *
      * Group 1: Component Name
-     * Group 2: Properties
      *
-     * @see https://regex101.com/r/3ujquL/2
+     * @see https://regex101.com/r/3ujquL/3
      */
     public function getComponentRegex(): string
     {
-        return "/<([{$this->typeOptions}][A-Z][a-zA-Z]+\b)\s*([a-zA-Z]+=.+\")?\s*\/?>/msU";
+        return "/<([$this->typeOptions][A-Z][a-zA-Z]+)[\/\s>]/ms";
     }
 }

--- a/src/Naming/AtomicDesignComponentNaming.php
+++ b/src/Naming/AtomicDesignComponentNaming.php
@@ -40,16 +40,6 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
         ]);
     }
 
-    public function selectorFromName(string $name, string $entryName): string
-    {
-        return join([
-            '.',
-            strtolower($name[0]),
-            '-',
-            lcfirst(substr($name, 1)),
-        ]);
-    }
-
     public function getEntryName(
         string $componentName,
         ?string $entrypointName,
@@ -67,6 +57,9 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
      * AButton
      * MContentCard
      * OPageHeader
+     *
+     * Group 1: Component Name
+     * Group 2: Properties
      *
      * @see https://regex101.com/r/3ujquL/2
      */

--- a/src/Naming/ComponentNamingInterface.php
+++ b/src/Naming/ComponentNamingInterface.php
@@ -8,8 +8,6 @@ interface ComponentNamingInterface
 
     public function pathFromComponentName(string $componentName): string;
 
-    public function selectorFromName(string $name, string $entryName): string;
-
     public function getEntryName(string $componentName, ?string $entrypointName, array $extraAttributes, string $type);
 
     public function getComponentRegex(): string;

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -42,7 +42,7 @@ class Component
             $start = $this->createTextNode("{% block default %}\n{% with embedContext %}");
             $end = $this->createTextNode("{% endwith %}\n{% endblock default %}");
 
-            $this->element->childNodes[0]->before($start); // start before first node
+            $this->element->insertBefore($start, $this->element->childNodes[0]); // start before first node
             $this->element->appendChild($end); // end after all children
 
             return;
@@ -58,11 +58,13 @@ class Component
             $start = $this->createTextNode("{% block $name %}\n{% with embedContext %}");
             $end = $this->createTextNode("{% endwith %}\n{% endblock $name %}");
 
-            $block->before($end); // end before block
-            $end->before($start); // start before end
+            $end = $this->element->insertBefore($end, $block); // end before block
+            $start = $this->element->insertBefore($start, $end); // start before end
 
             $childNodes = iterator_to_array($block->childNodes->getIterator());
-            $end->before(...$childNodes); // child before end
+            foreach($childNodes as $childNode) {
+                $this->element->insertBefore($childNode, $end);
+            }
 
             $block->remove();
         }
@@ -136,7 +138,7 @@ class Component
         );
         $end = $this->createTextNode("{% endembed %}");
 
-        $this->element->childNodes[0]->before($start); // start before first child
+        $this->element->insertBefore($start, $this->element->childNodes[0]);
         $this->element->appendChild($end); // end after all children
 
         return iterator_to_array($this->element->childNodes->getIterator());

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -6,6 +6,7 @@ use DOMAttr;
 use DOMElement;
 use DOMText;
 use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\VarDumper\VarDumper;
 
 class Component
 {
@@ -110,6 +111,8 @@ class Component
                 $key = str_replace('-', '', $key);
                 $key = lcfirst($key);
             }
+
+            VarDumper::dump($stringValue);
 
             $attributeObject[] = "$key: $escape$stringValue$escape";
         }

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -12,19 +12,18 @@ class Component
     public string $name;
     public DOMElement $element;
     public string $filePath;
+    public string $embedId;
 
-
-    /**
-     * @throws \Exception
-     */
     public function __construct(
         string $name,
         DOMElement $element,
-        string $filePath
+        string $filePath,
+        string $embedId
     ) {
         $this->filePath = $filePath;
         $this->element = $element;
         $this->name = $name;
+        $this->embedId = $embedId;
         $this->isSelfClosing = !$this->element->hasChildNodes();
     }
 
@@ -43,7 +42,7 @@ class Component
 
     private function getBlockNodes(string $name): array
     {
-        $start = $this->createTextNode("{% block $name %}\n{% with embedContext %}");
+        $start = $this->createTextNode("{% block $name %}\n{% with { props: $this->embedId } %}");
         $end = $this->createTextNode("{% endwith %}\n{% endblock $name %}");
 
         return [$start, $end];
@@ -147,7 +146,7 @@ class Component
         $parameterMap = $this->getTwigParameterMap();
 
         $start = $this->createTextNode(
-            "{% embed '$this->filePath' with { props: { $parameterMap }, embedContext: _context } %}"
+            "{% embed '$this->filePath' with { props: { $parameterMap }, $this->embedId } %}"
         );
         $end = $this->createTextNode("{% endembed %}");
 

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TwigComponentTools\TCTBundle\Preprocessor;
+
+class Component
+{
+    public int $originalLength;
+
+    public bool $selfClosing;
+
+    public int $originalEndPos;
+
+    private array $blocks = [];
+
+    public function __construct(
+        public string $tag,
+        public string $name,
+        public string $attributes,
+        public int $originalStartPos
+    ) {
+        $this->originalLength = strlen($tag);
+        $this->originalEndPos = $originalStartPos + $this->originalLength;
+        $this->selfClosing = '/' === $tag[$this->originalLength - 2];
+    }
+
+    public function render(): string
+    {
+
+    }
+}

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -9,19 +9,23 @@ use DOMText;
 class Component
 {
     public bool $isSelfClosing;
+    public string $name;
+    public DOMElement $element;
+    public string $filePath;
 
-    private bool $usesDefaultBlock;
 
     /**
      * @throws \Exception
      */
     public function __construct(
-        public string $name,
-        public DOMElement $element,
-        public string $filePath
+        string $name,
+        DOMElement $element,
+        string $filePath
     ) {
+        $this->filePath = $filePath;
+        $this->element = $element;
+        $this->name = $name;
         $this->isSelfClosing = !$this->element->hasChildNodes();
-        $this->usesDefaultBlock = false;
     }
 
     private function createTextNode(string $data): DOMText
@@ -35,7 +39,6 @@ class Component
         $numberOfBlocks = $blocks->length;
 
         if (0 === $numberOfBlocks) {
-            $this->usesDefaultBlock = true;
             $start = $this->createTextNode("{% block default %}\n{% with embedContext %}");
             $end = $this->createTextNode("{% endwith %}\n{% endblock default %}");
 
@@ -88,7 +91,7 @@ class Component
             $stringValue = urldecode($attribute->value);
             $key = $attribute->name;
 
-            $isVar = str_starts_with($stringValue, '{{') && str_ends_with($stringValue, '}}');
+            $isVar = strpos($stringValue, '{{') === 0 && strpos($stringValue, '}}') === strlen($stringValue) - 1;
 
             if ($isVar) {
                 $stringValue = trim(substr($stringValue, 2, -2));
@@ -104,7 +107,7 @@ class Component
                 $stringValue = 'true';
             }
 
-            if (str_contains($key, '-')) {
+            if (strpos($key, '-') !== FALSE) {
                 $key = ucwords($key, '-');
                 $key = str_replace('-', '', $key);
                 $key = lcfirst($key);

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -86,7 +86,7 @@ class Component
                 continue;
             }
 
-            $stringValue = $attribute->value;
+            $stringValue = urldecode($attribute->value);
             $key = $attribute->name;
 
             $isVar = str_starts_with($stringValue, '{{') && str_ends_with($stringValue, '}}');

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -5,8 +5,6 @@ namespace TwigComponentTools\TCTBundle\Preprocessor;
 use DOMAttr;
 use DOMElement;
 use DOMText;
-use Symfony\Component\String\Inflector\EnglishInflector;
-use Symfony\Component\VarDumper\VarDumper;
 
 class Component
 {
@@ -111,8 +109,6 @@ class Component
                 $key = str_replace('-', '', $key);
                 $key = lcfirst($key);
             }
-
-            VarDumper::dump($stringValue);
 
             $attributeObject[] = "$key: $escape$stringValue$escape";
         }

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -2,29 +2,162 @@
 
 namespace TwigComponentTools\TCTBundle\Preprocessor;
 
+use SimpleXMLElement;
+
 class Component
 {
     public int $originalLength;
 
-    public bool $selfClosing;
+    public bool $isSelfClosing;
+
+    public bool $usesDefaultBlock;
 
     public int $originalEndPos;
 
     private array $blocks = [];
 
+    private ?string $inner = null;
+
+    private SimpleXMLElement $simpleXMLElement;
+
+    private mixed $simpleXMLBLocks;
+
+    /**
+     * @throws \Exception
+     */
     public function __construct(
-        public string $tag,
+        public string $openingTag,
         public string $name,
-        public string $attributes,
-        public int $originalStartPos
+        public string $filePath,
+        public int $originalStartPos,
+        string $code
     ) {
-        $this->originalLength = strlen($tag);
-        $this->originalEndPos = $originalStartPos + $this->originalLength;
-        $this->selfClosing = '/' === $tag[$this->originalLength - 2];
+        $startTagLength = strlen($openingTag);
+
+        $this->isSelfClosing  = '/' === $openingTag[$startTagLength - 2];
+        $this->originalEndPos = $this->originalStartPos + $startTagLength;
+
+        if (!$this->isSelfClosing) {
+            $closingTag        = "</$name>";
+            $endOfOpeningTag   = $this->originalStartPos + $startTagLength;
+            $startOfClosingTag = strpos($code, $closingTag, $endOfOpeningTag);
+
+            $this->originalEndPos = $startOfClosingTag + strlen($closingTag);
+            $this->inner          = substr($code, $endOfOpeningTag, $startOfClosingTag - $endOfOpeningTag);
+        }
+
+        $this->originalLength = $this->originalEndPos - $this->originalStartPos;
+        $fullComponentCode    = substr($code, $this->originalStartPos, $this->originalLength);
+
+        if ($this->isSelfClosing) {
+            $fullComponentCode = str_replace('/>', "></$name>", $fullComponentCode);
+        }
+
+        $this->simpleXMLElement = new SimpleXMLElement($fullComponentCode);
+        $this->simpleXMLBLocks  = $this->simpleXMLElement->xpath("/$name/block");
+        $this->usesDefaultBlock = empty($this->simpleXMLBLocks);
     }
 
     public function render(): string
     {
+        if ($this->isSelfClosing) {
+            return $this->renderInclude();
+        }
 
+        return $this->renderEmbed();
+    }
+
+    private function renderInclude(): string
+    {
+        $parameterMap = $this->getTwigParameterMap();
+
+        return "{% include '$this->filePath' with { props: { $parameterMap } } %}";
+    }
+
+    private function getTwigParameterMap(): string
+    {
+        $attributeObject = [];
+        $attributes      = $this->simpleXMLElement->attributes();
+
+        /**
+         * @var SimpleXMLElement $value
+         */
+        foreach ($attributes as $key => $value) {
+            $isVar = str_starts_with($value, '{{') && str_ends_with($value, '}}');
+
+            if ($isVar) {
+                $value = trim(substr($value, 2, -2));
+            }
+
+            $escape = $isVar ? '' : '\'';
+
+            if (!$isVar) {
+                $value = str_replace('\'', '\\\'', $value);
+            }
+
+            $attributeObject[] = "$key: $escape$value$escape";
+        }
+
+        return implode(', ', $attributeObject);
+    }
+
+    private function renderEmbed(): string
+    {
+        $parameterMap = $this->getTwigParameterMap();
+
+        $parts = array_filter([
+            $this->getAllBlockSets(),
+            "{% embed '$this->filePath' with { props: { $parameterMap } } %}",
+            $this->getAllBlockPrints(),
+            '{% endembed %}',
+        ]);
+
+        return join(PHP_EOL, $parts);
+    }
+
+    private function getAllBlockSets(): ?string
+    {
+        if ($this->usesDefaultBlock) {
+            return $this->getBlockSet('default', $this->inner);
+        }
+
+        if (!is_iterable($this->simpleXMLBLocks)) {
+            return null;
+        }
+
+        $parts = [];
+        foreach ($this->simpleXMLBLocks as $xmlBlock) {
+            $attributes = $xmlBlock->attributes();
+            $name       = $attributes['name'];
+
+            $childParts = [];
+            foreach ($xmlBlock->children() as $child) {
+                $childParts[] = $child->asXml();
+            }
+
+            $parts[] = $this->getBlockSet($name, join(PHP_EOL, $childParts));
+        }
+
+        return join(PHP_EOL, $parts);
+    }
+
+    private function getBlockSet(string $name, string $contents): string
+    {
+        $id = uniqid($name.'_');
+
+        $this->blocks[$name] = $id;
+
+        return "{%- set $id -%}$contents{%- endset -%}";
+    }
+
+    private function getAllBlockPrints(): ?string
+    {
+        $parts = [];
+
+        foreach ($this->blocks as $name => $id) {
+            $parts[] = "{%- block $name -%}{{- $id -}}{%- endblock -%}";
+        }
+
+        return join(PHP_EOL, $parts);
     }
 }

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -105,7 +105,7 @@ class Component
             $stringValue = urldecode($attribute->value);
             $key = $attribute->name;
 
-            $isVar = strpos($stringValue, '{{') === 0 && strpos($stringValue, '}}') === strlen($stringValue) - 1;
+            $isVar = strpos($stringValue, '{{') === 0 && strpos($stringValue, '}}') === strlen($stringValue) - 2;
 
             if ($isVar) {
                 $stringValue = trim(substr($stringValue, 2, -2));

--- a/src/Preprocessor/Component.php
+++ b/src/Preprocessor/Component.php
@@ -41,8 +41,12 @@ class Component
         if (0 === $numberOfBlocks) {
             $start = $this->createTextNode("{% block default %}\n{% with embedContext %}");
             $end = $this->createTextNode("{% endwith %}\n{% endblock default %}");
+            /**
+             * @var \DOMNodeList $children
+             */
+            $children = $this->element->childNodes;
 
-            $this->element->insertBefore($start, $this->element->childNodes[0]); // start before first node
+            $this->element->insertBefore($start, $children->item(0)); // start before first node
             $this->element->appendChild($end); // end after all children
 
             return;
@@ -61,9 +65,12 @@ class Component
             $end = $this->element->insertBefore($end, $block); // end before block
             $start = $this->element->insertBefore($start, $end); // start before end
 
-            $childNodes = iterator_to_array($block->childNodes->getIterator());
-            foreach($childNodes as $childNode) {
-                $this->element->insertBefore($childNode, $end);
+            /**
+             * @var \DOMNodeList $children
+             */
+            $children = $this->element->childNodes;
+            for($index = $children->length - 1; $index >= 0; $index--) {
+                $this->element->insertBefore($children->item($index), $end);
             }
 
             $block->remove();
@@ -138,9 +145,15 @@ class Component
         );
         $end = $this->createTextNode("{% endembed %}");
 
-        $this->element->insertBefore($start, $this->element->childNodes[0]);
+
+        /**
+         * @var \DOMNodeList $children
+         */
+        $children = $this->element->childNodes;
+
+        $this->element->insertBefore($start, $children->item(0));
         $this->element->appendChild($end); // end after all children
 
-        return iterator_to_array($this->element->childNodes->getIterator());
+        return iterator_to_array($children);
     }
 }

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -2,9 +2,6 @@
 
 namespace TwigComponentTools\TCTBundle\Preprocessor;
 
-use Exception;
-use SimpleXMLElement;
-use Symfony\Component\VarDumper\VarDumper;
 use Twig\Source;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 
@@ -14,62 +11,37 @@ class ComponentPreprocessor implements PreprocessorInterface
 
     private string $componentRegex;
 
-    private array $blocks = [];
-
     public function __construct(ComponentNamingInterface $componentNaming)
     {
         $this->componentNaming = $componentNaming;
-        $this->componentRegex = $this->componentNaming->getComponentRegex();
+        $this->componentRegex  = $this->componentNaming->getComponentRegex();
     }
 
+    /**
+     * @throws \Exception
+     */
     public function processSourceContext(Source $source): Source
     {
-        $component = null;
-        $code = $source->getCode();
-        $lastPosition = 0;
+        /**
+         * @var ?\TwigComponentTools\TCTBundle\Preprocessor\Component $component
+         */
+        $component     = null;
+        $code          = $source->getCode();
+        $lastPosition  = 0;
         $hasComponents = false;
 
         while ($this->getNextComponent($code, $lastPosition, $component)) {
-            $this->blocks = [];
             $hasComponents = true;
 
-            [
-                'name' => $name,
-                'startPosition' => $startPosition,
-                // 'tag'           => $openingTag,
-                'endPosition' => $endOfOpeningTag,
-                'attributes' => $attributes,
-                'selfClosing' => $selfClosing,
-                'length' => $openingTagLength,
-            ] = $component;
-
-            if (!$selfClosing) {
-                $closingTag = "</$name>";
-                $startOfClosingTag = strpos($code, $closingTag, $endOfOpeningTag);
-
-                $code = $this->replaceClosingTag($code, $startOfClosingTag, $closingTag);
-                $code = $this->replaceDefaultBlock($code, $name, $endOfOpeningTag, $startOfClosingTag);
-            }
-
-            $code = $this->replaceOpeningTag(
+            $code = substr_replace(
                 $code,
-                $name,
-                $attributes,
-                $startPosition,
-                $openingTagLength,
-                $selfClosing
+                $component->render(),
+                $component->originalStartPos,
+                $component->originalLength
             );
-
-            $blocks = implode(PHP_EOL, $this->blocks);
-            $lastPosition = $startPosition + 1;
-            $code = substr_replace($code, $blocks, $startPosition, 0);
         }
 
         if ($hasComponents) {
-            $code = $this->replaceBlocks($code);
-
-            VarDumper::dump($code);
-
             return new Source($code, $source->getName(), $source->getPath());
         }
 
@@ -77,13 +49,15 @@ class ComponentPreprocessor implements PreprocessorInterface
     }
 
     /**
-     * @param string    $code         Code to search components in
-     * @param int       $lastPosition Offset at which to start searching for the next component
-     * @param Component $component    The component information will be saved in this array
+     * @param string     $code         Code to search components in
+     * @param int        $lastPosition Offset at which to start searching for the next component
+     * @param ?Component $component    The component information will be saved in this array
      *
      * @return bool True if it found a component
+     *
+     * @throws \Exception
      */
-    public function getNextComponent(string $code, int $lastPosition, Component &$component): bool
+    public function getNextComponent(string $code, int $lastPosition, ?Component &$component): bool
     {
         $matches = [];
 
@@ -99,115 +73,20 @@ class ComponentPreprocessor implements PreprocessorInterface
             return false;
         }
 
-        list($fullMatch, $nameMatch, $attributesMatch) = $matches;
-        list($tag, $start) = $fullMatch;
+        list($fullMatch, $nameMatch) = $matches;
+        list($openingTag, $start) = $fullMatch;
         list($name) = $nameMatch;
-        list($attributes) = $attributesMatch;
+
+        $path = $this->componentNaming->pathFromComponentName($name);
 
         $component = new Component(
-            $tag,
+            $openingTag,
             $name,
-            $attributes,
-            $start
+            $path,
+            $start,
+            $code
         );
 
         return true;
-    }
-
-    private function replaceClosingTag(string $code, int $closingPosition, string $closingTag): string
-    {
-        return substr_replace($code, '{% endembed %}', $closingPosition, strlen($closingTag));
-    }
-
-    private function replaceDefaultBlock(
-        string $code,
-        string $name,
-        int $endOfOpeningTag,
-        int $startOfClosingTag
-    ): string {
-        $inner = substr(
-            $code,
-            $endOfOpeningTag,
-            $startOfClosingTag - $endOfOpeningTag
-        );
-
-        $defaultBlock = !str_starts_with(trim($inner), '<block');
-
-        if ($defaultBlock) {
-            $id = uniqid($name).'_default';
-            $blockSet = "\n{% set {$id} %}$inner{% endset %}\n";
-
-            $this->blocks[] = $blockSet;
-
-            $code = substr_replace(
-                $code,
-                "\n{% block default %}{{- $id -}}{% endblock %}\n",
-                $endOfOpeningTag,
-                strlen($inner)
-            );
-        }
-
-        return $code;
-    }
-
-    private function replaceOpeningTag(
-        string $code,
-        string $name,
-        string $attributes,
-        int $startPosition,
-        int $tagLength,
-        bool $selfClosing
-    ): string {
-        $twigTag = $selfClosing ? 'include' : 'embed';
-        $path = $this->componentNaming->pathFromComponentName($name);
-        $params = $this->getTwigParameterMap($attributes);
-
-        return substr_replace(
-            $code,
-            "{% $twigTag '$path' with { props: { $params } } %}",
-            $startPosition,
-            $tagLength
-        );
-    }
-
-    private function getTwigParameterMap(string $attributesString): string
-    {
-        $attributeObject = [];
-        $attributesString = htmlspecialchars($attributesString, ENT_NOQUOTES);
-
-        try {
-            $element = new SimpleXMLElement("<element $attributesString />");
-            $attributes = $element->attributes();
-        } catch (Exception $exception) {
-            $attributes = [];
-        }
-
-        /**
-         * @var SimpleXMLElement $value
-         */
-        foreach ($attributes as $key => $value) {
-            $isVar = str_starts_with($value, '{{') && str_ends_with($value, '}}');
-
-            if ($isVar) {
-                $value = trim(substr($value, 2, -2));
-            }
-
-            $escape = $isVar ? '' : '\'';
-
-            if (!$isVar) {
-                $value = str_replace('\'', '\\\'', $value);
-            }
-
-            $attributeObject[] = "$key: $escape$value$escape";
-        }
-
-        return implode(', ', $attributeObject);
-    }
-
-    private function replaceBlocks(string $code): string
-    {
-        $code = preg_replace('/<block #([a-z]+)>/', '{% block $1 %}', $code);
-
-        return str_replace('</block>', '{% endblock %}', $code);
     }
 }

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -4,7 +4,6 @@ namespace TwigComponentTools\TCTBundle\Preprocessor;
 
 use DOMDocument;
 use DOMElement;
-use Symfony\Component\VarDumper\VarDumper;
 use Twig\Source;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 
@@ -20,70 +19,148 @@ class ComponentPreprocessor implements PreprocessorInterface
         $this->componentRegex = $this->componentNaming->getComponentRegex();
     }
 
-    /**
-     * @throws \Exception
-     */
     public function processSourceContext(Source $source): Source
     {
-        $code = $source->getCode();
+        $code = $this->getSanitizedCode($source);
         $components = $this->getComponentList($code);
 
         if (empty($components)) {
             return $source;
         }
 
-        libxml_use_internal_errors(true);
-        $dom = new DOMDocument();
-        $parsingCode = mb_convert_encoding("<tct-root>$code</tct-root>", 'HTML-ENTITIES', 'UTF-8');
-        $dom->loadHTML($parsingCode, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOXMLDECL);
-        libxml_use_internal_errors(false);
+        $embedId = $this->getEmbedId($source);
+        $document = $this->createDOMDocument($code);
 
         foreach ($components as $componentName) {
-            $templatePath = $this->componentNaming->pathFromComponentName($componentName);
-            $selector = strtolower($componentName);
-            $componentNodeList = $dom->getElementsByTagName($selector);
-            $numberOfComponents = $componentNodeList->length;
+            $this->processAllComponents($componentName, $document, $embedId);
+        }
 
-            for ($index = 0; $index < $numberOfComponents; $index++) {
-                /**
-                 * @var DOMElement $componentNode
-                 */
-                $componentNode = $componentNodeList->item(
-                    0
-                ); // $componentNodeList is "live" -> The first item will always be the next non-altered item.
+        return new Source(
+            $this->getTranspiledCode($document, $embedId),
+            $source->getName(),
+            $source->getPath()
+        );
+    }
 
-                $component = new Component($componentName, $componentNode, $templatePath);
-                $transpiledNodes = $component->getTranspiledNodes();
-                $fragment = $dom->createDocumentFragment();
+    /** @noinspection PhpUnnecessaryLocalVariableInspection */
+    private function getTranspiledCode(DOMDocument $document, string $embedId): string
+    {
+        $code = $this->saveDocument($document);
+        $code = $this->fixUrlEncodings($code);
+        $code = $this->insertEmbedId($code, $embedId);
 
-                foreach ($transpiledNodes as $transpiledNode) {
-                    $fragment->appendChild($transpiledNode);
-                }
+        return $code;
+    }
 
-                $componentNode->parentNode->replaceChild($fragment, $componentNode);
+    /**
+     * @see https://regex101.com/r/eVctpW/1
+     * @noinspection PhpUnnecessaryLocalVariableInspection
+     */
+    private function getSanitizedCode(Source $source): string
+    {
+        $code = $source->getCode();
+        $code = preg_replace("/\{#.*#}/sU", '', $code);
+
+        return $code;
+    }
+
+    private function processAllComponents(string $componentName, DOMDocument $document, string $embedId): void
+    {
+        $selector = strtolower($componentName);
+        $templatePath = $this->componentNaming->pathFromComponentName($componentName);
+        $componentNodeList = $document->getElementsByTagName($selector);
+        $numberOfComponents = $componentNodeList->length;
+
+        for ($index = 0; $index < $numberOfComponents; $index++) {
+            $componentNode = $componentNodeList->item(0);
+
+            if(!$componentNode instanceof DOMElement){
+                continue;
             }
+
+            $this->processComponent($componentNode, $componentName, $templatePath, $embedId);
+        }
+    }
+
+    private function processComponent(DOMElement $element, string $name, string $path, string $embedId): void
+    {
+        $component = new Component($name, $element, $path, $embedId);
+        $transpiledNodes = $component->getTranspiledNodes();
+        $fragment = $element->ownerDocument->createDocumentFragment();
+
+        foreach ($transpiledNodes as $transpiledNode) {
+            $fragment->appendChild($transpiledNode);
         }
 
-        $root = $dom->getElementsByTagName('tct-root')[0];
+        $element->parentNode->replaceChild($fragment, $element);
+    }
 
-        $transpiledCode = "";
-        foreach ($root->childNodes as $node) {
-            $transpiledCode .= $dom->saveHTML($node);
+    private function createDOMDocument(string $code): DOMDocument
+    {
+        libxml_use_internal_errors(true);
+        $document = new DOMDocument();
+        $parsingCode = mb_convert_encoding("<tct-root>$code</tct-root>", 'HTML-ENTITIES', 'UTF-8');
+        $document->loadHTML($parsingCode, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOXMLDECL);
+        libxml_use_internal_errors(false);
+
+        return $document;
+    }
+
+    private function getEmbedId(Source $source): string
+    {
+        $fileName = pathinfo($source->getPath(), PATHINFO_FILENAME);
+
+        return uniqid($fileName);
+    }
+
+    private function insertEmbedId(string $code, string $embedId): string
+    {
+        return substr_replace(
+            $code,
+            "\n{% set $embedId = props|default({}) %}",
+            $this->getExtendsEndPosition($code),
+            0
+        );
+    }
+
+    private function getExtendsEndPosition(string $code): int
+    {
+        $extendMatches = [];
+        $matched = preg_match("/\{%\s*extends.*%}/", $code, $extendMatches, PREG_OFFSET_CAPTURE);
+
+        if ($matched === 0) {
+            return 0;
         }
 
-        $transpiledCode = preg_replace_callback(
+        list($fullMatch, $position) = $extendMatches[0];
+
+        return strlen($fullMatch) + $position;
+    }
+
+    private function fixUrlEncodings(string $code): string
+    {
+        return preg_replace_callback(
             "/(src|href)=\"(.*)\"/",
             function ($match) {
                 $attribute = $match[1];
                 $value = urldecode($match[2]);
+
                 return "$attribute=\"$value\"";
             },
-            $transpiledCode
+            $code
         );
+    }
 
-        VarDumper::dump($transpiledCode);
+    private function saveDocument(DOMDocument $document): string
+    {
+        $root = $document->getElementsByTagName('tct-root')[0];
 
-        return new Source($transpiledCode, $source->getName(), $source->getPath());
+        $transpiledCode = '';
+        foreach ($root->childNodes as $node) {
+            $transpiledCode .= $document->saveHTML($node);
+        }
+
+        return $transpiledCode;
     }
 
     private function getComponentList(string $code): ?array

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -14,7 +14,7 @@ class ComponentPreprocessor implements PreprocessorInterface
     public function __construct(ComponentNamingInterface $componentNaming)
     {
         $this->componentNaming = $componentNaming;
-        $this->componentRegex  = $this->componentNaming->getComponentRegex();
+        $this->componentRegex = $this->componentNaming->getComponentRegex();
     }
 
     /**
@@ -25,12 +25,11 @@ class ComponentPreprocessor implements PreprocessorInterface
         /**
          * @var ?\TwigComponentTools\TCTBundle\Preprocessor\Component $component
          */
-        $component     = null;
-        $code          = $source->getCode();
-        $lastPosition  = 0;
+        $component = null;
+        $code = $source->getCode();
         $hasComponents = false;
 
-        while ($this->getNextComponent($code, $lastPosition, $component)) {
+        while ($this->getNextComponent($code, $component)) {
             $hasComponents = true;
 
             $code = substr_replace(
@@ -42,6 +41,8 @@ class ComponentPreprocessor implements PreprocessorInterface
         }
 
         if ($hasComponents) {
+//            VarDumper::dump($code);
+
             return new Source($code, $source->getName(), $source->getPath());
         }
 
@@ -49,15 +50,14 @@ class ComponentPreprocessor implements PreprocessorInterface
     }
 
     /**
-     * @param string     $code         Code to search components in
-     * @param int        $lastPosition Offset at which to start searching for the next component
-     * @param ?Component $component    The component information will be saved in this array
+     * @param string     $code      Code to search components in
+     * @param ?Component $component The component information will be saved in this array
      *
      * @return bool True if it found a component
      *
      * @throws \Exception
      */
-    public function getNextComponent(string $code, int $lastPosition, ?Component &$component): bool
+    public function getNextComponent(string $code, ?Component &$component): bool
     {
         $matches = [];
 
@@ -65,8 +65,7 @@ class ComponentPreprocessor implements PreprocessorInterface
                 $this->componentRegex,
                 $code,
                 $matches,
-                PREG_OFFSET_CAPTURE,
-                $lastPosition
+                PREG_OFFSET_CAPTURE
             );
 
         if (!$found) {

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -42,12 +42,13 @@ class ComponentPreprocessor implements PreprocessorInterface
             $componentNodeList = $dom->getElementsByTagName($selector);
             $numberOfComponents = $componentNodeList->length;
 
-            for ($index = 0; $index < $numberOfComponents; $index ++)
-            {
+            for ($index = 0; $index < $numberOfComponents; $index++) {
                 /**
                  * @var DOMElement $componentNode
                  */
-                $componentNode = $componentNodeList->item(0); // $componentNodeList is "live" -> The first item will always be the next non-altered item.
+                $componentNode = $componentNodeList->item(
+                    0
+                ); // $componentNodeList is "live" -> The first item will always be the next non-altered item.
 
                 $component = new Component($componentName, $componentNode, $templatePath);
                 $transpiledNodes = $component->getTranspiledNodes();
@@ -67,6 +68,8 @@ class ComponentPreprocessor implements PreprocessorInterface
         foreach ($root->childNodes as $node) {
             $transpiledCode .= $dom->saveHTML($node);
         }
+
+        $transpiledCode = preg_replace("/%7B%7B(\w+)%7D%7D/", '{{$1}}', $transpiledCode);
 
         return new Source($transpiledCode, $source->getName(), $source->getPath());
     }

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -66,7 +66,7 @@ class ComponentPreprocessor implements PreprocessorInterface
 
         $root = $dom->getElementsByTagName('tct-root')[0];
 
-        $transpiledCode = '';
+        $transpiledCode = "";
         foreach ($root->childNodes as $node) {
             $transpiledCode .= $dom->saveHTML($node);
         }
@@ -80,6 +80,8 @@ class ComponentPreprocessor implements PreprocessorInterface
             },
             $transpiledCode
         );
+
+        VarDumper::dump($transpiledCode);
 
         return new Source($transpiledCode, $source->getName(), $source->getPath());
     }

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -33,7 +33,7 @@ class ComponentPreprocessor implements PreprocessorInterface
 
         libxml_use_internal_errors(true);
         $dom = new DOMDocument;
-        $dom->loadHTML("<tct-root>$code</tct-root>", LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML("<tct-root>$code</tct-root>", LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOXMLDECL);
         libxml_use_internal_errors(false);
 
         foreach ($components as $componentName) {
@@ -61,8 +61,10 @@ class ComponentPreprocessor implements PreprocessorInterface
             }
         }
 
+        $root = $dom->getElementsByTagName('tct-root')[0];
+
         $transpiledCode = '';
-        foreach ($dom->firstChild->childNodes as $node) {
+        foreach ($root->childNodes as $node) {
             $transpiledCode .= $dom->saveHTML($node);
         }
 

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -2,6 +2,7 @@
 
 namespace TwigComponentTools\TCTBundle\Preprocessor;
 
+use Symfony\Component\VarDumper\VarDumper;
 use Twig\Source;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -69,7 +69,7 @@ class ComponentPreprocessor implements PreprocessorInterface
             $transpiledCode .= $dom->saveHTML($node);
         }
 
-        $transpiledCode = preg_replace("/%7B%7B(\w+)%7D%7D/", '{{$1}}', $transpiledCode);
+        $transpiledCode = preg_replace("/%7B%7B%20(.*)%20%7D%7D/", '{{ $1 }}', $transpiledCode);
 
         return new Source($transpiledCode, $source->getName(), $source->getPath());
     }

--- a/src/Preprocessor/ComponentPreprocessor.php
+++ b/src/Preprocessor/ComponentPreprocessor.php
@@ -4,7 +4,6 @@ namespace TwigComponentTools\TCTBundle\Preprocessor;
 
 use DOMDocument;
 use DOMElement;
-use Symfony\Component\VarDumper\VarDumper;
 use Twig\Source;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 
@@ -66,8 +65,6 @@ class ComponentPreprocessor implements PreprocessorInterface
         foreach ($dom->firstChild->childNodes as $node) {
             $transpiledCode .= $dom->saveHTML($node);
         }
-
-        VarDumper::dump($transpiledCode);
 
         return new Source($transpiledCode, $source->getName(), $source->getPath());
     }

--- a/src/Resources/config/routes.yaml
+++ b/src/Resources/config/routes.yaml
@@ -1,0 +1,3 @@
+storybook_render:
+  path: /
+  controller: TwigComponentTools\TCTBundle\Controller\StorybookController::storybookComponent

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -4,6 +4,9 @@ services:
     autoconfigure: true
     public: false
 
+  TwigComponentTools\TCTBundle\Controller\StorybookController:
+    public: true
+
   TwigComponentTools\TCTBundle\Naming\AtomicDesignComponentNaming:
     public: true
 

--- a/src/TagRenderer/EncoreComponentTagRenderer.php
+++ b/src/TagRenderer/EncoreComponentTagRenderer.php
@@ -2,6 +2,7 @@
 
 namespace TwigComponentTools\TCTBundle\TagRenderer;
 
+use Symfony\Component\VarDumper\VarDumper;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 

--- a/src/TagRenderer/EncoreComponentTagRenderer.php
+++ b/src/TagRenderer/EncoreComponentTagRenderer.php
@@ -19,6 +19,11 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
         $this->tagRenderer     = $tagRenderer;
     }
 
+    public function renderBodyTags(array $loadedComponents): string
+    {
+        return $this->renderTags($loadedComponents);
+    }
+
     public function renderTags(
         array $loadedComponents,
         array $extraAttributes = [],
@@ -31,7 +36,6 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
 
         foreach ($loadedComponents as $name) {
             $entryName = $this->componentNaming->getEntryName($name, $entrypointName, $extraAttributes, $type);
-            $selector  = $this->componentNaming->selectorFromName($name, $entryName);
 
             $jsTags = $this->tagRenderer->renderWebpackScriptTags(
                 $entryName,
@@ -42,7 +46,7 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
 
             $jsTags = preg_replace(
                 "/$entryName(\..*)?\.js\"/",
-                "$entryName$1.js\" data-class-name=\"$name\" data-selector=\"$selector\"",
+                "$entryName$1.js\" data-component=\"$name\"",
                 $jsTags
             );
 
@@ -64,10 +68,5 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
     public function renderHeadTags(array $loadedComponents): string
     {
         return $this->renderTags($loadedComponents, ['async' => true, 'defer' => true], 'head');
-    }
-
-    public function renderBodyTags(array $loadedComponents): string
-    {
-        return $this->renderTags($loadedComponents);
     }
 }

--- a/src/TagRenderer/EncoreComponentTagRenderer.php
+++ b/src/TagRenderer/EncoreComponentTagRenderer.php
@@ -2,7 +2,6 @@
 
 namespace TwigComponentTools\TCTBundle\TagRenderer;
 
-use Symfony\Component\VarDumper\VarDumper;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use TwigComponentTools\TCTBundle\Naming\ComponentNamingInterface;
 


### PR DESCRIPTION
This PR introduces more stable DOM usage and less RegEx.

* It significantly improves performance of the preprocessor step.
* It introduces embed context-aware blocks: code within blocks will now have the same context as the file they are written, not the file they are declared in. This moves the implementation closer to Vue.js.
* It allows boolean (`true` if present, `false` if absent) attributes, but enforces kebab-case attributes.
* blocks now use true XML syntax with `name="content"` instead of `#content`. This is longer, but more stable, and a preparation for additional attributes.

@ESKempken I will provide additional information in a call.