### PR TITLE
Search & Replace feat. DOMDocument

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="customRulesets">
+      <list>
+        <RulesetDescriptor>
+          <option name="name" value="jobs.center PHPMD rule set" />
+          <option name="path" value="/var/www/p3103-toffd-aktionswebseite/phpmd.xml" />
+        </RulesetDescriptor>
+      </list>
+    </option>
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="codingStandard" value="Custom" />
+    <option name="rulesetPath" value="/var/www/toffd/p3103-toffd-aktionswebseite/.php-cs-fixer.php" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="codingStandard" value="Custom" />
+    <option name="customRuleset" value="/var/www/p3103-toffd-aktionswebseite/phpcs.xml" />
+    <option name="extensions" value="php" />
+    <option name="installedPaths" value="/var/www/p3103-toffd-aktionswebseite" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpIncludePathManager">
     <include_path>
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
@@ -25,9 +48,18 @@
       <path value="$PROJECT_DIR$/vendor/symfony/filesystem" />
       <path value="$PROJECT_DIR$/vendor/symfony/webpack-encore-bundle" />
       <path value="$PROJECT_DIR$/vendor/symfony/deprecation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/twig-bundle" />
+      <path value="$PROJECT_DIR$/vendor/symfony/translation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/twig-bridge" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.4">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Blocks can be defined and used like in any regular twig template. There are a fe
 {# File: @components/Atom/AButton/AButton.twig #}
 
 <button type="button" class="a-button -{{ props.theme|default('grey') }}">
-  {% block AButton_default %}{% endblock %}
+  {% block AButton__default %}{% endblock %}
 </button>
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "twig-component-tools/tct-bundle",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "type": "symfony-bundle",
   "license": "MIT",
   "autoload": {
@@ -15,12 +15,12 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=7.4",
     "ext-simplexml": "*",
     "twig/twig": "^3.3",
-    "symfony/http-kernel": "^5.4",
-    "symfony/webpack-encore-bundle": "^1.14",
-    "symfony/dependency-injection": "^5.4"
+    "symfony/http-kernel": "^4.4|^5.4|^6.1",
+    "symfony/webpack-encore-bundle": "^v1.15",
+    "symfony/dependency-injection": "^4.4|^5.4|^6.1"
   },
   "archive": {
     "exclude": [

--- a/src/Naming/AtomicDesignComponentNaming.php
+++ b/src/Naming/AtomicDesignComponentNaming.php
@@ -9,21 +9,30 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
         'a' => 'Atom',
         'm' => 'Molecule',
         'o' => 'Organism',
+        'p' => 'Page',
         't' => 'Template',
     ];
 
     private string $typeOptions;
+    private array $typeAliases;
 
     public function __construct()
     {
-        $this->typeOptions = array_reduce(self::TYPES, fn ($carry, $type) => $carry.$type[0]);
+        $this->typeOptions = array_reduce(self::TYPES, fn($carry, $type) => $carry.$type[0]);
+        $this->typeAliases = array_map(fn($type) => '@' . strtolower($type), self::TYPES);
+        $this->typeAliases[] = '@components';
     }
 
+    /**
+     * Return the component name if it fits one of the component aliases (e.g. @components or @page)
+     */
     public function componentNameFromPath(string $path): ?string
     {
         $parts = explode('/', $path);
 
-        if ('@components' !== $parts[0]) {
+        $intersection = array_intersect($this->typeAliases, $parts);
+
+        if (empty($intersection)) {
             return null;
         }
 
@@ -37,16 +46,6 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
             self::TYPES[strtolower($componentName[0])],
             $componentName,
             "{$componentName}.twig",
-        ]);
-    }
-
-    public function selectorFromName(string $name, string $entryName): string
-    {
-        return join([
-            '.',
-            strtolower($name[0]),
-            '-',
-            lcfirst(substr($name, 1)),
         ]);
     }
 
@@ -68,10 +67,12 @@ class AtomicDesignComponentNaming implements ComponentNamingInterface
      * MContentCard
      * OPageHeader
      *
-     * @see https://regex101.com/r/3ujquL/2
+     * Group 1: Component Name
+     *
+     * @see https://regex101.com/r/3ujquL/3
      */
     public function getComponentRegex(): string
     {
-        return "/<([{$this->typeOptions}][A-Z][a-zA-Z]+\b)\s*([a-zA-Z]+=.+\")?\s*\/?>/msU";
+        return "/<([$this->typeOptions][A-Z][a-zA-Z]+)[\/\s>]/ms";
     }
 }

--- a/src/Naming/ComponentNamingInterface.php
+++ b/src/Naming/ComponentNamingInterface.php
@@ -8,8 +8,6 @@ interface ComponentNamingInterface
 
     public function pathFromComponentName(string $componentName): string;
 
-    public function selectorFromName(string $name, string $entryName): string;
-
     public function getEntryName(string $componentName, ?string $entrypointName, array $extraAttributes, string $type);
 
     public function getComponentRegex(): string;

--- a/src/TagRenderer/EncoreComponentTagRenderer.php
+++ b/src/TagRenderer/EncoreComponentTagRenderer.php
@@ -16,7 +16,7 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
         TagRenderer $tagRenderer
     ) {
         $this->componentNaming = $componentNaming;
-        $this->tagRenderer     = $tagRenderer;
+        $this->tagRenderer = $tagRenderer;
     }
 
     public function renderTags(
@@ -31,7 +31,6 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
 
         foreach ($loadedComponents as $name) {
             $entryName = $this->componentNaming->getEntryName($name, $entrypointName, $extraAttributes, $type);
-            $selector  = $this->componentNaming->selectorFromName($name, $entryName);
 
             $jsTags = $this->tagRenderer->renderWebpackScriptTags(
                 $entryName,
@@ -42,11 +41,18 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
 
             $jsTags = preg_replace(
                 "/$entryName(\..*)?\.js\"/",
-                "$entryName$1.js\" data-class-name=\"$name\" data-selector=\"$selector\"",
+                "$entryName$1.js\" data-component=\"$name\"",
                 $jsTags
             );
 
             $tags[] = $jsTags;
+
+            $tags[] = $this->tagRenderer->renderWebpackLinkTags(
+                'style-'.$entryName,
+                $packageName,
+                $entrypointName,
+                $extraAttributes
+            );
 
             $tags[] = $this->tagRenderer->renderWebpackLinkTags(
                 $entryName,
@@ -63,11 +69,11 @@ class EncoreComponentTagRenderer implements ComponentTagRenderInterface
 
     public function renderHeadTags(array $loadedComponents): string
     {
-        return $this->renderTags($loadedComponents, ['async' => true, 'defer' => true], 'head');
+        return $this->renderTags($loadedComponents, ['async' => false, 'defer' => false], 'head');
     }
 
     public function renderBodyTags(array $loadedComponents): string
     {
-        return $this->renderTags($loadedComponents);
+        return $this->renderTags($loadedComponents, ['async' => false, 'defer' => true]);
     }
 }


### PR DESCRIPTION
This implementation aims to use simple search-n-replace to handle the bulk of the transpiling, but use DOMDocument parsing for TCT component attributes.

fixes #5
fixes #4